### PR TITLE
Adds ObservationRecorder.create

### DIFF
--- a/can-observation-recorder-test.js
+++ b/can-observation-recorder-test.js
@@ -32,3 +32,13 @@ QUnit.test('start returns the same deps as stop', function(){
     QUnit.equal(dependencies0Start, dependencies0Stop, "dependencies0Start is the same as dependencies0Stop");
 
 });
+
+QUnit.test("created adds a dependency to the childDependencies of the parent", function(){
+		var foo = function(){};
+
+		observationRecorder.start();
+		observationRecorder.created(foo);
+		var dependencies = observationRecorder.stop();
+
+		QUnit.ok(dependencies.childDependencies.has(foo), "dependencies has foo in the child deps");
+});

--- a/can-observation-recorder.js
+++ b/can-observation-recorder.js
@@ -1,10 +1,13 @@
 var namespace = require("can-namespace");
+var canSymbol = require("can-symbol");
 
 // Contains stack of observation records created by pushing with `.start`
 // and popping with `.stop()`.
 // The top of the stack is the "target" observation record - the record that calls
 // to `ObservationRecorder.add` get added to.
 var stack = [];
+
+var addParentSymbol = canSymbol.for("can.addParent");
 
 var ObservationRecorder = {
     stack: stack,
@@ -67,6 +70,9 @@ var ObservationRecorder = {
 			var top = stack[stack.length - 1];
 			if(top) {
 				top.childDependencies.add(obs);
+				if(obs[addParentSymbol]) {
+					obs[addParentSymbol](top);
+				}
 			}
 		},
     ignore: function(fn){
@@ -93,6 +99,7 @@ var ObservationRecorder = {
             traps: null,
             keyDependencies: new Map(),
             valueDependencies: new Set(),
+						//childDependencies: new Set(),
             ignore: 0
         };
     },

--- a/can-observation-recorder.js
+++ b/can-observation-recorder.js
@@ -12,13 +12,14 @@ var ObservationRecorder = {
     	var deps = {
             keyDependencies: new Map(),
             valueDependencies: new Set(),
+						childDependencies: new Set(),
 
             // `traps` and `ignore` are here only for performance
             // reasons. They work with `ObservationRecorder.ignore` and `ObservationRecorder.trap`.
             traps: null,
-            ignore: 0    		
+            ignore: 0
     	};
-    	
+
         stack.push(deps);
 
         return deps;
@@ -62,6 +63,12 @@ var ObservationRecorder = {
     		}
     	}
     },
+		created: function(obs){
+			var top = stack[stack.length - 1];
+			if(top) {
+				top.childDependencies.add(obs);
+			}
+		},
     ignore: function(fn){
     	return function(){
     		if (stack.length) {

--- a/doc/created.md
+++ b/doc/created.md
@@ -1,0 +1,14 @@
+@function can-observation-recorder.created created
+@parent can-observation-recorder/methods
+
+@description Adds a child dependency to the parent observation's childDependencies.
+
+@signature `ObservationRecorder.created(object)`
+
+Signals that an object was created. Adds the created observable to the top of the stack.
+
+```js
+ObservationRecorder.created(object);
+```
+
+@param {Object} object An observable object that was recently created.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     ]
   },
   "dependencies": {
-    "can-namespace": "^1.0.0"
+    "can-namespace": "^1.0.0",
+    "can-symbol": "^1.6.1"
   },
   "devDependencies": {
     "jshint": "^2.9.1",


### PR DESCRIPTION
This adds the `created` method, that signals that an object was created.
The parent observation contains a Set of childDependencies. It can use
this to teardown children when itself is re-run.